### PR TITLE
Add XpHandler, generalize get player data logic

### DIFF
--- a/Assets/_Scripts/App/Systems/Xp.meta
+++ b/Assets/_Scripts/App/Systems/Xp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfe2ad884fa655e4692923b933ebf3b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/App/Systems/Xp/XpHandler.cs
+++ b/Assets/_Scripts/App/Systems/Xp/XpHandler.cs
@@ -29,7 +29,7 @@ namespace CosmicShore.App.Systems.Xp
     public class XpHandler
     {
         /// <summary>
-        /// Captain Xp key for querying data from PlayFab data storage, not used for now.
+        /// Captain Xp key for querying data from PlayFab data storage, not used for PlayFab API calls now.
         /// </summary>
         private const string CaptainXpKey = "CaptainXP";
 
@@ -55,6 +55,7 @@ namespace CosmicShore.App.Systems.Xp
         public static void OnLoadCaptainXpData(GetUserDataResult result)
         {
             ClassXpData = ConvertResultToCaptainXpData(result);
+            
             foreach (var key in ClassXpData.Keys)
                 Debug.Log($"OnLoadCaptainXpData - ClassXpData.ShipClassXpData.Keys: {key}");
             
@@ -73,7 +74,7 @@ namespace CosmicShore.App.Systems.Xp
                     (Dictionary<ShipTypes, CaptainXpData>)JsonConvert
                     .DeserializeObject(result.Data[CaptainXpKey].Value,
                     typeof(Dictionary<ShipTypes, CaptainXpData>))
-                    : null;
+                    : new();
         }
     }
 }

--- a/Assets/_Scripts/App/Systems/Xp/XpHandler.cs
+++ b/Assets/_Scripts/App/Systems/Xp/XpHandler.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using CosmicShore.Integrations.PlayFab.PlayerData;
+using Newtonsoft.Json;
+using PlayFab.ClientModels;
+using UnityEngine;
+
+namespace CosmicShore.App.Systems.Xp
+{
+    /// <summary>
+    /// Captain Xp Data
+    /// Contains Captain class elements - Space, Time, Charge, Mass
+    /// </summary>
+    public struct CaptainXpData
+    {
+        public int Space;
+        public int Time;
+        public int Charge;
+        public int Mass;
+
+        public CaptainXpData(int space, int time, int charge, int mass)
+        {
+            Space = space;
+            Time = time;
+            Charge = charge;
+            Mass = mass;
+        }
+    }
+
+    public class XpHandler
+    {
+        /// <summary>
+        /// Captain Xp key for querying data from PlayFab data storage, not used for now.
+        /// </summary>
+        private const string CaptainXpKey = "CaptainXP";
+
+        /// <summary>
+        /// Class Xp Data
+        /// Used for storing Captain Xp Data for each Ship type.
+        /// </summary>
+        public static Dictionary<ShipTypes, CaptainXpData> ClassXpData = new();
+
+        /// <summary>
+        /// A wrapper to get player data for now.
+        /// </summary>
+        public static void LoadCaptainXpData()
+        {
+            // Fow now we don't pass any keys, pull all player data and query locally.
+            PlayerDataController.Instance.GetPlayerData();
+        }
+        
+        /// <summary>
+        /// Process user data result upon pulling player data, convert the result to Class Xp Data, and log them in the console.
+        /// </summary>
+        /// <param name="result">Query result for player data</param>
+        public static void OnLoadCaptainXpData(GetUserDataResult result)
+        {
+            ClassXpData = ConvertResultToCaptainXpData(result);
+            foreach (var key in ClassXpData.Keys)
+                Debug.Log($"OnLoadCaptainXpData - ClassXpData.ShipClassXpData.Keys: {key}");
+            
+            Debug.Log($"OnLoadCaptainXpData - Custom Data: {result.CustomData}");
+        }
+
+        /// <summary>
+        /// A helper class convert player data result to Class Xp Data
+        /// if the data does not exist, return null.
+        /// </summary>
+        /// <param name="result">Player data query result</param>
+        /// <returns></returns>
+        private static Dictionary<ShipTypes, CaptainXpData> ConvertResultToCaptainXpData(GetUserDataResult result)
+        {
+                return result.Data.ContainsKey(CaptainXpKey)?
+                    (Dictionary<ShipTypes, CaptainXpData>)JsonConvert
+                    .DeserializeObject(result.Data[CaptainXpKey].Value,
+                    typeof(Dictionary<ShipTypes, CaptainXpData>))
+                    : null;
+        }
+    }
+}

--- a/Assets/_Scripts/App/Systems/Xp/XpHandler.cs.meta
+++ b/Assets/_Scripts/App/Systems/Xp/XpHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ffeb554edca4f04985126807ddaa6bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Integrations/Playfab/PlayerData/PlayerDataController.cs
+++ b/Assets/_Scripts/Integrations/Playfab/PlayerData/PlayerDataController.cs
@@ -35,7 +35,7 @@ namespace CosmicShore.Integrations.PlayFab.PlayerData
         {
             AuthenticationManager.OnLoginSuccess -= XpHandler.LoadCaptainXpData;
             AuthenticationManager.OnLoginSuccess -= LoadPlayerProfile;
-            OnGettingPlayerData += XpHandler.OnLoadCaptainXpData;
+            OnGettingPlayerData -= XpHandler.OnLoadCaptainXpData;
         }
         
         void InitializePlayerClientInstanceAPI()


### PR DESCRIPTION
Several changes for Captain Xp Handling:
- PlayerDataController handles more generalized player data updating and pulling.
- XpHandler gets player data from PlayFab, query Captain Xp Data for each ship locally and convert it to Class Xp Data.