### PR TITLE
Wire up 5 of 12 elemental floats for Sparrow, Serpent, Squirrel

### DIFF
--- a/Assets/_Prefabs/Spaceships/Serpent.prefab
+++ b/Assets/_Prefabs/Spaceships/Serpent.prefab
@@ -772,7 +772,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c8f865735b87b6a43a367be3280d8332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boostMultiplier: 3
+  boostMultiplier:
+    Enabled: 1
+    Value: 1.2
+    Min: 1.2
+    Max: 2.7
+    element: 4
   boostDuration: 3
   resourceIndex: 1
   resourceCost: 0.25
@@ -1877,9 +1882,10 @@ MonoBehaviour:
   MinimumSpeed: 10
   ThrottleScaler: 50
   DefaultMinimumSpeed: 10
-  DefaultThrottleScaler:
+  DefaultThrottleScaler: 50
+  ThrottleScalerMultiplier:
     Enabled: 0
-    Value: 18
+    Value: 1
     Min: 0
     Max: 0
     element: 0

--- a/Assets/_Prefabs/Spaceships/Sparrow.prefab
+++ b/Assets/_Prefabs/Spaceships/Sparrow.prefab
@@ -479,13 +479,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   wrappedAction: {fileID: 1854718600018079252}
   heatResourceIndex: 1
-  heatBuildRate:
-    Enabled: 0
-    Value: 0.01
-    Min: 0
-    Max: 0
-    element: 0
-  heatDecayRate: 0.01
+  heatBuildRate: 0.02
+  heatDecayRate:
+    Enabled: 1
+    Value: 0.05
+    Min: 0.05
+    Max: 0.8
+    element: 1
   overheatDuration: 6
 --- !u!1 &3938548809082189982
 GameObject:
@@ -1034,12 +1034,13 @@ MonoBehaviour:
   MinimumSpeed: 10
   ThrottleScaler: 50
   DefaultMinimumSpeed: 10
-  DefaultThrottleScaler:
-    Enabled: 1
-    Value: 20
-    Min: 20
-    Max: 50
-    element: 4
+  DefaultThrottleScaler: 50
+  ThrottleScalerMultiplier:
+    Enabled: 0
+    Value: 1
+    Min: 0
+    Max: 0
+    element: 0
   PitchScaler: 80
   YawScaler: 80
   RollScaler: 30

--- a/Assets/_Prefabs/Spaceships/Squirrel.prefab
+++ b/Assets/_Prefabs/Spaceships/Squirrel.prefab
@@ -349,12 +349,13 @@ MonoBehaviour:
   MinimumSpeed: 0
   ThrottleScaler: 0
   DefaultMinimumSpeed: 0
-  DefaultThrottleScaler:
-    Enabled: 0
-    Value: 60
-    Min: 0
-    Max: 0
-    element: 0
+  DefaultThrottleScaler: 50
+  ThrottleScalerMultiplier:
+    Enabled: 1
+    Value: 1
+    Min: 1
+    Max: 2.5
+    element: 4
   PitchScaler: 50
   YawScaler: 50
   RollScaler: 50
@@ -846,6 +847,16 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
         type: 3}
+      propertyPath: Scale.Max
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
+        type: 3}
+      propertyPath: Scale.Min
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
+        type: 3}
       propertyPath: fuelAmount
       value: 0
       objectReference: {fileID: 0}
@@ -857,7 +868,7 @@ PrefabInstance:
     - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
         type: 3}
       propertyPath: Scale.Value
-      value: 50
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
         type: 3}
@@ -874,6 +885,16 @@ PrefabInstance:
         type: 3}
       propertyPath: skimVisualFX
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
+        type: 3}
+      propertyPath: Scale.Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
+        type: 3}
+      propertyPath: Scale.element
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7751815150560592197, guid: 6540c78597c2dcc468123b270169fc44,
         type: 3}

--- a/Assets/_Scripts/Game/Environment/WarpField/WarpFieldController.cs
+++ b/Assets/_Scripts/Game/Environment/WarpField/WarpFieldController.cs
@@ -27,7 +27,7 @@ public class WarpFieldController : MonoBehaviour
     {
         var fieldResult = warpFieldData.HybridVector(player).magnitude;
         //cameraManager.SetBothCameraDistances(-fieldResult); //TODO: set clip plane to half the distance
-        shipController.ThrottleScaler = shipController.DefaultThrottleScaler.Value * fieldResult;
+        shipController.ThrottleScaler = shipController.DefaultThrottleScaler * fieldResult;
         shipController.MinimumSpeed = shipController.DefaultMinimumSpeed * fieldResult;
 
         player.localScale = Vector3.one * fieldResult;

--- a/Assets/_Scripts/Game/Ship/ShipActions/ConsumeBoostAction.cs
+++ b/Assets/_Scripts/Game/Ship/ShipActions/ConsumeBoostAction.cs
@@ -7,13 +7,14 @@ using CosmicShore.Core;
 public class ConsumeBoostAction : ShipAction
 {
     ShipStatus shipData;
-    [SerializeField] float boostMultiplier = 4f;
+    [SerializeField] ElementalFloat boostMultiplier = new(4f);
     [SerializeField] float boostDuration = 4f;
     [SerializeField] int resourceIndex = 1;
     [SerializeField] float resourceCost = .25f;
 
     protected override void Start()
     {
+        BindElementalFloats(ship);
         shipData = ship.GetComponent<ShipStatus>();
         ship.boostMultiplier = 0;
     }
@@ -31,9 +32,9 @@ public class ConsumeBoostAction : ShipAction
     {
         ship.ResourceSystem.ChangeResourceAmount(resourceIndex,-resourceCost);
         shipData.Boosting = true;
-        ship.boostMultiplier += boostMultiplier;
+        ship.boostMultiplier += boostMultiplier.Value;
         yield return new WaitForSeconds(boostDuration);
-        ship.boostMultiplier -= boostMultiplier;
+        ship.boostMultiplier -= boostMultiplier.Value;
         if (ship.boostMultiplier <= 0)
         {
             shipData.Boosting = false;

--- a/Assets/_Scripts/Game/Ship/ShipActions/OverheatingAction.cs
+++ b/Assets/_Scripts/Game/Ship/ShipActions/OverheatingAction.cs
@@ -7,8 +7,7 @@ public class OverheatingAction : ShipAction
     [SerializeField] ShipAction wrappedAction;
     [SerializeField] int heatResourceIndex = 0;
     [SerializeField] float heatBuildRate = 0.02f;
-    [SerializeField] float heatDecayRate = 0.04f;
-    [SerializeField] ElementalFloat heatDecayIntervalSeconds = new(0.1f);  // How long before one quantum of heat decays
+    [SerializeField] ElementalFloat heatDecayRate = new(0.04f);
     [SerializeField] float overheatDuration = 3f;
 
     ShipStatus shipStatus;
@@ -74,8 +73,8 @@ public class OverheatingAction : ShipAction
     {
         while (heatResource.CurrentAmount > 0)
         {
-            resourceSystem.ChangeResourceAmount(heatResourceIndex, -heatDecayRate);
-            yield return new WaitForSeconds(heatDecayIntervalSeconds.Value);
+            resourceSystem.ChangeResourceAmount(heatResourceIndex, -heatDecayRate.Value);
+            yield return new WaitForSeconds(0.1f);
         }
         
         heatResource.CurrentAmount = 0;

--- a/Assets/_Scripts/Game/Ship/ShipActions/OverheatingAction.cs
+++ b/Assets/_Scripts/Game/Ship/ShipActions/OverheatingAction.cs
@@ -6,8 +6,9 @@ public class OverheatingAction : ShipAction
 {
     [SerializeField] ShipAction wrappedAction;
     [SerializeField] int heatResourceIndex = 0;
-    [SerializeField] ElementalFloat heatBuildRate = new(0.02f);
+    [SerializeField] float heatBuildRate = 0.02f;
     [SerializeField] float heatDecayRate = 0.04f;
+    [SerializeField] ElementalFloat heatDecayIntervalSeconds = new(0.1f);  // How long before one quantum of heat decays
     [SerializeField] float overheatDuration = 3f;
 
     ShipStatus shipStatus;
@@ -53,7 +54,7 @@ public class OverheatingAction : ShipAction
     {
         while (heatResource.CurrentAmount < heatResource.MaxAmount)
         {
-            resourceSystem.ChangeResourceAmount(heatResourceIndex, heatBuildRate.Value);
+            resourceSystem.ChangeResourceAmount(heatResourceIndex, heatBuildRate);
             yield return new WaitForSeconds(0.1f);
         }
 
@@ -74,7 +75,7 @@ public class OverheatingAction : ShipAction
         while (heatResource.CurrentAmount > 0)
         {
             resourceSystem.ChangeResourceAmount(heatResourceIndex, -heatDecayRate);
-            yield return new WaitForSeconds(0.1f);
+            yield return new WaitForSeconds(heatDecayIntervalSeconds.Value);
         }
         
         heatResource.CurrentAmount = 0;

--- a/Assets/_Scripts/Game/Ship/ShipTransformer.cs
+++ b/Assets/_Scripts/Game/Ship/ShipTransformer.cs
@@ -22,7 +22,8 @@ public class ShipTransformer : MonoBehaviour
     [HideInInspector] public float ThrottleScaler;
 
     public float DefaultMinimumSpeed = 10f;
-    public ElementalFloat DefaultThrottleScaler = new(50f);
+    public float DefaultThrottleScaler = 50f;
+    public ElementalFloat ThrottleScalerMultiplier = new(1f);
 
     public float PitchScaler = 130f;
     public float YawScaler = 130f;
@@ -45,7 +46,7 @@ public class ShipTransformer : MonoBehaviour
         resourceSystem = ship.GetComponent<ResourceSystem>();
 
         MinimumSpeed = DefaultMinimumSpeed;
-        ThrottleScaler = DefaultThrottleScaler.Value;
+        ThrottleScaler = DefaultThrottleScaler;
         accumulatedRotation = transform.rotation;
         inputController = ship.InputController;
     }
@@ -53,7 +54,7 @@ public class ShipTransformer : MonoBehaviour
     public void Reset()
     {
         MinimumSpeed = DefaultMinimumSpeed;
-        ThrottleScaler = DefaultThrottleScaler.Value;
+        ThrottleScaler = DefaultThrottleScaler;
         accumulatedRotation = transform.rotation;
         resourceSystem.Reset();
         shipStatus.Reset();
@@ -165,7 +166,7 @@ public class ShipTransformer : MonoBehaviour
         }
         if (shipStatus.ChargedBoostDischarging) boostAmount *= shipStatus.ChargedBoostCharge;
         if (inputController != null)
-        speed = Mathf.Lerp(speed, inputController.XDiff * ThrottleScaler * boostAmount + MinimumSpeed, lerpAmount * Time.deltaTime);
+        speed = Mathf.Lerp(speed, inputController.XDiff * ThrottleScaler * ThrottleScalerMultiplier.Value * boostAmount + MinimumSpeed, lerpAmount * Time.deltaTime);
 
         speed *= throttleMultiplier;
         shipStatus.Speed = speed;


### PR DESCRIPTION
squirrel space and sparrow space were wired up previously

for reference, here are the initial ranges (from level 0 to level 10 of each element)

- squirrel space [10, 160]
- squirrel time [1, 2.5]
- sparrow charge [0.05, 0.8]
- sparrow space [1500, 4000]  (already in place, I didn't adjust it -- but I suspect the lower bound is too high)
- serpent time [1.2, 2.7]

TODO

- ~~"unclobber" other classes' floats~~ appears unnecessary this time?
- ~~tune param ranges~~