### PR TITLE
Fix missing DailyChallenge pref key

### DIFF
--- a/Assets/_Scripts/App/Systems/DailyChallengeSystem.cs
+++ b/Assets/_Scripts/App/Systems/DailyChallengeSystem.cs
@@ -70,6 +70,7 @@ namespace CosmicShore.App.Systems
             PrefKeys.Add(RewardTierOneClaimedPrefKey);
             PrefKeys.Add(RewardTierTwoClaimedPrefKey);
             PrefKeys.Add(RewardTierThreeClaimedPrefKey);
+            PrefKeys.Add(RewardTierOneSatisfiedPrefKey);
             PrefKeys.Add(RewardTierTwoSatisfiedPrefKey);
             PrefKeys.Add(RewardTierThreeSatisfiedPrefKey);
         }


### PR DESCRIPTION
## Summary
- add missing DailyChallenge pref key when syncing player data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cd0f6d46c832bb98591af08056334