### PR TITLE
Fix singleton log typos

### DIFF
--- a/Assets/_Scripts/Utility/Singleton.cs
+++ b/Assets/_Scripts/Utility/Singleton.cs
@@ -110,13 +110,13 @@ namespace CosmicShore.Utilities
                     T[] results = Resources.FindObjectsOfTypeAll<T>();
                     if (results.Length == 0)
                     {
-                        Debug.LogError("SingletonScriptableObject -> Instance -> results lenght is 0 for type" + typeof(T).ToString() + ".");
+                        Debug.LogError("SingletonScriptableObject -> Instance -> results length is 0 for type" + typeof(T).ToString() + ".");
                         return null;
 
                     }
                     if (results.Length > 1)
                     {
-                        Debug.LogError("SingletonScriptableObject -> Instance -> results lenght is greather than for type" + typeof(T).ToString() + ".");
+                        Debug.LogError("SingletonScriptableObject -> Instance -> results length is greater than for type" + typeof(T).ToString() + ".");
                         return null;
 
                     }


### PR DESCRIPTION
## Summary
- fix length and greater spelling in singleton logs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cd59cc7d0832bbf6601eac8937b3b