### PR TITLE
Add single trail block spawnable

### DIFF
--- a/Assets/_Scripts/Game/Environment/MiniGameObjects/SpawnableSingleTrailBlock.cs
+++ b/Assets/_Scripts/Game/Environment/MiniGameObjects/SpawnableSingleTrailBlock.cs
@@ -1,0 +1,21 @@
+using CosmicShore.Core;
+using UnityEngine;
+
+public class SpawnableSingleTrailBlock : SpawnableAbstractBase
+{
+    [SerializeField] TrailBlock trailBlock;
+    [SerializeField] Vector3 blockScale = Vector3.one;
+    static int BlocksSpawned = 0;
+
+    public override GameObject Spawn()
+    {
+        GameObject container = new();
+        container.name = "SingleTrailBlock" + BlocksSpawned++;
+
+        var trail = new Trail();
+        CreateBlock(Vector3.zero, Vector3.forward, container.name + "::BLOCK::0", trail, blockScale, trailBlock, container);
+
+        trails.Add(trail);
+        return container;
+    }
+}

--- a/Assets/_Scripts/Game/Environment/MiniGameObjects/SpawnableSingleTrailBlock.cs.meta
+++ b/Assets/_Scripts/Game/Environment/MiniGameObjects/SpawnableSingleTrailBlock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 610f3c731818449b901254caf217f87b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `SpawnableSingleTrailBlock` script to spawn a single TrailBlock
- include associated `.meta` file with unique GUID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc73d4e10832b956d80f60fb31618