### PR TITLE
Prevent scene dirty flags from edit-mode scripts

### DIFF
--- a/Assets/_Scripts/Utility/GuidSO.cs
+++ b/Assets/_Scripts/Utility/GuidSO.cs
@@ -25,6 +25,10 @@ namespace CosmicShore.Utilities
 
         protected virtual void OnValidate()
         {
+            if (Application.isPlaying)
+            {
+                return;
+            }
             m_InstanceName = name;
 
             if (m_Guid == null || m_Guid.Length == 0)

--- a/Assets/_Scripts/Utility/TagSO.cs
+++ b/Assets/_Scripts/Utility/TagSO.cs
@@ -10,6 +10,10 @@ namespace CosmicShore.Utilities
 
         protected override void OnValidate()
         {
+            if (Application.isPlaying)
+            {
+                return;
+            }
             if (string.IsNullOrEmpty(m_TagName))
             {
                 m_TagName = name;


### PR DESCRIPTION
## Summary
- avoid running validation logic during play mode in GuidSO and TagSO
- revert accidental changes in other scripts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6b49ca0832b8e9674fdf6e34816