### PR TITLE
Fix camera transitions and follow

### DIFF
--- a/Assets/_Scripts/Game/Camera/CustomCameraController.cs
+++ b/Assets/_Scripts/Game/Camera/CustomCameraController.cs
@@ -10,7 +10,8 @@ namespace CosmicShore.Game.CameraSystem
         [SerializeField] float followSmoothTime = 0.2f;
         [SerializeField] float rotationSmoothTime = 5f;
         [SerializeField] bool useFixedUpdate = false;
-        [SerializeField] bool ignoreRoll = false;
+        [SerializeField] bool ignoreRoll = true;
+        [SerializeField] float fieldOfView = 60f;
 
         Camera cachedCamera;
         Vector3 velocity;
@@ -44,6 +45,8 @@ namespace CosmicShore.Game.CameraSystem
         void Awake()
         {
             cachedCamera = GetComponent<Camera>();
+            cachedCamera.fieldOfView = fieldOfView;
+            cachedCamera.useOcclusionCulling = false;
         }
 
         void LateUpdate()
@@ -63,7 +66,7 @@ namespace CosmicShore.Game.CameraSystem
             if (followTarget == null)
                 return;
 
-            // 1) Build an offset?rotation that follows the ship’s forward+pitch but ignores its roll
+            // 1) Build an offset?rotation that follows the shipâ€™s forward+pitch but ignores its roll
             Quaternion offsetRot = ignoreRoll
                 ? Quaternion.LookRotation(followTarget.forward, Vector3.up)
                 : followTarget.rotation;

--- a/Assets/_Scripts/Game/Managers/CameraManager.cs
+++ b/Assets/_Scripts/Game/Managers/CameraManager.cs
@@ -39,6 +39,7 @@ public class CameraManager : SingletonPersistent<CameraManager>
 
     public float CloseCamDistance;
     public float FarCamDistance;
+    [SerializeField] float startTransitionDistance = 40f;
 
     Camera vCam;
 
@@ -216,7 +217,9 @@ public class CameraManager : SingletonPersistent<CameraManager>
                 cameraData.renderPostProcessing = true;
             }
             InitializeRuntimeOffset();
-            SetOffsetPosition(runtimeFollowOffset);
+            Vector3 finalOffset = runtimeFollowOffset;
+            SetRuntimeFollowOffset(runtimeFollowOffset + Vector3.back * startTransitionDistance);
+            SetOffsetPosition(finalOffset);
         }
         else if (activeCamera == deathCamera)
         {


### PR DESCRIPTION
## Summary
- tune camera follow to avoid roll and set FOV
- disable camera occlusion culling
- smoothly transition player camera with small zoom offset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68758c3238fc832990a055ce6916e30a