### PR TITLE
Fix follow cam smoothing

### DIFF
--- a/Assets/_Scripts/Game/Camera/CustomCameraController.cs
+++ b/Assets/_Scripts/Game/Camera/CustomCameraController.cs
@@ -9,6 +9,8 @@ namespace CosmicShore.Game.CameraSystem
         [SerializeField] Vector3 followOffset = new(0f, 10f, -50f);
         [SerializeField] float followSmoothTime = 0.2f;
         [SerializeField] float rotationSmoothTime = 5f;
+        [SerializeField] bool smoothPosition = true;
+        [SerializeField] bool smoothRotation = true;
         [SerializeField] bool useFixedUpdate = false;
         [SerializeField] float farClipPlane = 10000f;
         [SerializeField] float fieldOfView = 60f;
@@ -67,15 +69,25 @@ namespace CosmicShore.Game.CameraSystem
 
             // 2) Move the camera to ship.position + that rotated offset
             Vector3 desiredPos = followTarget.position + offsetRot * followOffset;
-            transform.position = Vector3.SmoothDamp(transform.position, desiredPos, ref velocity, followSmoothTime);
+            if (smoothPosition && followSmoothTime > 0f)
+                transform.position = Vector3.SmoothDamp(transform.position, desiredPos, ref velocity, followSmoothTime);
+            else
+                transform.position = desiredPos;
 
             // 3) Look at the ship using its up vector so roll is preserved
             Vector3 toTarget = followTarget.position - transform.position;
             Quaternion targetRot = Quaternion.LookRotation(toTarget, followTarget.up);
 
             // 4) Smooth?damp into that rotation
-            float t = 1f - Mathf.Exp(-rotationSmoothTime * Time.deltaTime);
-            transform.rotation = Quaternion.Slerp(transform.rotation, targetRot, t);
+            if (smoothRotation)
+            {
+                float t = 1f - Mathf.Exp(-rotationSmoothTime * Time.deltaTime);
+                transform.rotation = Quaternion.Slerp(transform.rotation, targetRot, t);
+            }
+            else
+            {
+                transform.rotation = targetRot;
+            }
         }
 
         public void SetFollowTarget(Transform target) => followTarget = target;
@@ -84,6 +96,9 @@ namespace CosmicShore.Game.CameraSystem
             followOffset = offset;
         }
         public Vector3 GetFollowOffset() => followOffset;
+
+        public void EnableSmoothFollow(bool enable) => smoothPosition = enable;
+        public void EnableSmoothRotation(bool enable) => smoothRotation = enable;
 
         public void SetFieldOfView(float fov) => cachedCamera.fieldOfView = fov;
         public void SetClipPlanes(float near, float far)

--- a/Assets/_Scripts/Game/Managers/CameraManager.cs
+++ b/Assets/_Scripts/Game/Managers/CameraManager.cs
@@ -137,6 +137,7 @@ public class CameraManager : SingletonPersistent<CameraManager>
     public void OnMainMenu()
     {
         SetMainMenuCameraActive();
+        playerCamera.EnableSmoothFollow(true);
         _themeManagerData.SetBackgroundColor(Camera.main);
     }
 
@@ -150,6 +151,7 @@ public class CameraManager : SingletonPersistent<CameraManager>
     {
         playerFollowTarget = _transform;
         playerCamera.SetFollowTarget(playerFollowTarget);
+        playerCamera.EnableSmoothFollow(!FollowOverride);
         deathCamera.SetFollowTarget(playerFollowTarget);
         _themeManagerData.SetBackgroundColor(Camera.main);
 


### PR DESCRIPTION
## Summary
- add smoothing toggles to `CustomCameraController`
- disable smoothing when camera follow target is overridden
- ensure menu camera resets smoothing

## Testing
- `bash -lc 'dotnet --version'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876aae3b7408329b5606de365b4c69d