### PR TITLE
Fix camera distance and follow smoothing

### DIFF
--- a/Assets/_Scripts/Game/Camera/CustomCameraController.cs
+++ b/Assets/_Scripts/Game/Camera/CustomCameraController.cs
@@ -67,7 +67,14 @@ namespace CosmicShore.Game.CameraSystem
             Quaternion offsetRot = followTarget.rotation;
             Vector3 desiredPos = followTarget.position + offsetRot * followOffset;
 
-            transform.position = Vector3.SmoothDamp(transform.position, desiredPos, ref velocity, followSmoothTime);
+            Vector3 currentLocal = followTarget.InverseTransformPoint(transform.position);
+            Vector3 desiredLocal = followTarget.InverseTransformPoint(desiredPos);
+
+            currentLocal.z = Mathf.SmoothDamp(currentLocal.z, desiredLocal.z, ref velocity.z, followSmoothTime);
+            currentLocal.x = desiredLocal.x;
+            currentLocal.y = desiredLocal.y;
+
+            transform.position = followTarget.TransformPoint(currentLocal);
             
             Vector3 toTarget = followTarget.position - transform.position;
             Quaternion targetRot = Quaternion.LookRotation(toTarget, followTarget.up);

--- a/Assets/_Scripts/Game/Managers/CameraManager.cs
+++ b/Assets/_Scripts/Game/Managers/CameraManager.cs
@@ -134,6 +134,8 @@ public class CameraManager : SingletonPersistent<CameraManager>
         return playerCamera.transform;
     }
 
+    public Vector3 CurrentOffset => runtimeFollowOffset;
+
     public void OnMainMenu()
     {
         SetMainMenuCameraActive();

--- a/Assets/_Scripts/Game/Ship/ShipCameraCustomizer.cs
+++ b/Assets/_Scripts/Game/Ship/ShipCameraCustomizer.cs
@@ -43,6 +43,10 @@ namespace CosmicShore
                 {
                     case ShipCameraOverrides.CloseCam:
                         cameraManager.CloseCamDistance = closeCamDistance;
+                        cameraManager.SetOffsetPosition(new Vector3(
+                            cameraManager.CurrentOffset.x,
+                            cameraManager.CurrentOffset.y,
+                            closeCamDistance));
                         break;
                     case ShipCameraOverrides.FarCam:
                         cameraManager.FarCamDistance = farCamDistance.Value;


### PR DESCRIPTION
## Summary
- allow retrieving current camera offset
- update ship camera customization to apply CloseCam offset
- smooth only along the forward axis when following to remove lateral lag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879283fa05c8329a3aace9939853a76